### PR TITLE
update Linuxbrew instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ __linuxbrew commands__
 
 If FFmpeg has already been installed with these options then skip next step. 
 
-`brew install ffmpeg --with-freetype --with-sdl2`
+`brew install ffmpeg --with-freetype`
 
 sdl2 is necessary to build FFmpeg with FFplay, but removing it after build will avoid conflicts between other installations of sdl2.
 


### PR DESCRIPTION
Since FFmpeg version 4.0 or 4.1 (sorry, I don’t remember) the `--with-sdl2` option is set by default.