### PR TITLE
nicer output

### DIFF
--- a/audiorecorder.1
+++ b/audiorecorder.1
@@ -1,4 +1,8 @@
 .TH audiorecorder 1 "github.com/amiaopensource/audiorecorder" "2018\-06\-15" "AMIA Open Source"
+.\" Turn off justification for nroff.
+.if n .ad l
+.\" Turn off hyphenation.
+.nh
 .SH NAME
 audiorecorder \- Tool for calibration and recording of analog audio sources
 .SH SYNOPSIS


### PR DESCRIPTION
- turn off justification for `nroff`
- turn off hyphenation, because it makes many mistakes in technical documents